### PR TITLE
Issue6 - Promote bearer token to top level optional field Signed-off-by: Mikkel Hagen hagenm@vmware.com

### DIFF
--- a/lib/fluent/plugin/out_vmware_log_intelligence.rb
+++ b/lib/fluent/plugin/out_vmware_log_intelligence.rb
@@ -13,6 +13,7 @@ module Fluent::Plugin
 
     config_param :http_compress, :bool, :default => false
     config_param :endpoint_url, :string
+    config_param :bearer_token, :string, default: ''
     config_param :http_retry_statuses, :string, default: ''
     config_param :read_timeout, :integer, default: 60
     config_param :open_timeout, :integer, default: 60
@@ -58,6 +59,9 @@ module Fluent::Plugin
           set_gzip_header(element)
         end
         if element.name == 'headers'
+          if @bearer_token != ''
+            element['Authorization'] = 'Bearer ' + @bearer_token
+          end
           headers = element.to_hash
         end
       end


### PR DESCRIPTION
Closes #6 Need to be able to pass bearer token as an env var.

I have left it an optional parameter but AFAIK LINT only supports bearer token auth?  If that is the case it really should be promoted to a mandatory field as with endpoint_url.  Also, this allows you to still specify other headers but if you specify another authorization in the header field the bearer token will overwrite it.

Testing:

```
Using config:
<match vmc.**>
  @type vmware_log_intelligence
  endpoint_url "#{ENV['LINT_URL']}"
  bearer_token "#{ENV['LINT_TOKEN']}"
  verify_ssl true
  <headers>
    Content-Type application/json
  </headers>
  <buffer>
    chunk_limit_records 300
    flush_interval 3s
    retry_max_times 3
  </buffer>
  <format>
    @type json
    tag_key message
  </format>
</match>

2020-12-24 04:17:55 +0000 [info]: parsing config file is succeeded path="/fluentd/etc/fluent.conf"
2020-12-24 04:17:55 +0000 [info]: gem 'fluent-plugin-vmware-log-intelligence' version '2.0.5'
2020-12-24 04:17:55 +0000 [info]: gem 'fluentd' version '1.11.5'
2020-12-24 04:17:56 +0000 [info]: using configuration file: <ROOT>
  <match vmc.**>
    @type vmware_log_intelligence
    endpoint_url "xxx"
    bearer_token "xxx"
    verify_ssl true
    <headers>
      Content-Type application/json
      Authorization Bearer xxxx
    </headers>
    <buffer>
      chunk_limit_records 300
      flush_interval 3s
      retry_max_times 3
    </buffer>
    <format>
      @type json
      tag_key message
    </format>
  </match>
</ROOT>
2020-12-24 04:17:56 +0000 [info]: starting fluentd-1.11.5 pid=6 ruby="2.7.1"
2020-12-24 04:17:57 +0000 [info]: adding match pattern="vmc.**" type="vmware_log_intelligence"
2020-12-24 04:17:57 +0000 [info]: #0 fluentd worker is now running worker=0
```