### PR TITLE
Update to ruby 3.0+, add debug

### DIFF
--- a/fluent-plugin-vmware-log-intelligence.gemspec
+++ b/fluent-plugin-vmware-log-intelligence.gemspec
@@ -38,13 +38,13 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency "fluentd", ">= 0.14.20"
-  s.add_dependency "http", ">= 0.9.8"
+  s.add_dependency "http", ">= 4.0"
   s.add_dependency "myslog", "~> 0.0"
   s.add_dependency "fluent-plugin-mysqlslowquery", ">= 0.0.9"
-  s.add_development_dependency "rake", ">= 0.9.2"
-  s.add_development_dependency "bundler", ">= 1.3.4"
-  s.add_development_dependency 'test-unit', '~> 3.1.0'
-  s.add_development_dependency 'webmock', '~> 3.4.0'
+  s.add_development_dependency "rake", ">= 13.0.0"
+  s.add_development_dependency "bundler", ">= 2.4.0"
+  s.add_development_dependency 'test-unit', '~> 3.5.0'
+  s.add_development_dependency 'webmock', '~> 3.10.0'
   s.add_development_dependency 'fluent-plugin-detect-exceptions', '>= 0.0.12'
   s.add_development_dependency 'fluent-plugin-concat', '>= 2.0.0'
   s.add_development_dependency 'fluent-plugin-kubernetes_metadata_filter', '>= 2.0.0'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,5 @@
 # Copyright (c) 2013 ablagoev
-# Copyright 2018 VMware, Inc.
+# Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: MIT
 
 require 'coveralls'

--- a/test/plugin/test_http_client.rb
+++ b/test/plugin/test_http_client.rb
@@ -10,13 +10,13 @@ class HttpClientTest < Test::Unit::TestCase
     stub_request(:post, url).to_return(:status => [429, "User out of ingestion quota."])
   end
 
-  def test_check_quota
+  def test_quota_reached
     http_client = create_http_client()
-    assert_equal http_client.check_quota, true
+    assert_equal http_client.quota_reached, false
 
     stub_server_out_of_quota
-    http_client.post(JSON.dump(sample_record()))
-    assert_equal http_client.check_quota, false
+    http_client.post(Yajl.dump(sample_record()))
+    assert_equal http_client.quota_reached, true
   end
 
   def stub_server_unavailable(url=DEFAULT_URL)
@@ -72,7 +72,7 @@ class HttpClientTest < Test::Unit::TestCase
     http_client = create_http_client()
     stub_server_returns_500
     assert_raise RuntimeError do
-      http_client.post(JSON.dump(sample_record()))
+      http_client.post(Yajl.dump(sample_record()))
     end
   end
 
@@ -80,16 +80,16 @@ class HttpClientTest < Test::Unit::TestCase
     http_client = create_http_client()
     stub_server_raise_error
     assert_raise IOError do
-      http_client.post(JSON.dump(sample_record()))
+      http_client.post(Yajl.dump(sample_record()))
     end
   end
 
   def test_post_logs
     stub_post_logs
     http_client = create_http_client()
-    http_client.post(JSON.dump(sample_record()))
+    http_client.post(Yajl.dump(sample_record()))
 
     stub_post_logs
-    http_client.post(JSON.dump(sample_record()))
+    http_client.post(Yajl.dump(sample_record()))
   end
 end


### PR DESCRIPTION
- update to Ruby 3.0 as the min version
- add several debug messages
- move to Yajl from JSON for slight performance increase
- add last_request_time to compressed as well instead of only uncompressed messages
- change check_quota to quota_reached and fix inversion to avoid double negative
- update deprecation of `URI.regexp`